### PR TITLE
Fix escaping zombies

### DIFF
--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -91,7 +91,7 @@ static const SDL_Color CYAN = { 0, 255, 255, 255 };
 static const int UPDATE_INTERVAL_MILLIS = 3000;
 static const int ZOMBIE_INTERVAL_MILLIS = 10000;
 
-static const int PROJECTILE_SPEED = 6;
+static const int PROJECTILE_SPEED = 2;
 static const int PROJECTILE_SIZE = 30;
 
 static const int ZOMBIE_SPEED = 60;

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -329,11 +329,6 @@ int Grid::checkCollision(Player* player)
 				{
 					destroyZombie(t);
 					defeatedZombies++;
-					if (defeatedZombies == 5)
-					{
-						defeatedZombies = 0;
-						return 1;
-					}
 				}
 				projectiles.erase(projectiles.begin() + k);
 				break;
@@ -345,15 +340,28 @@ int Grid::checkCollision(Player* player)
 	{
 		if (zombies.at(m).getPosition().x <= 40)
 		{
+			escapedZombies++;
 			destroyZombie(m);
 			player->updateHealth(-50);
 			if (player->getHealth() <= 0)
 			{
 				player->setHealth(150);
+				defeatedZombies = 0;
+				escapedZombies = 0;
 				return 2;
 			}
 		}
 	}
 
-	return 0;
+	if (defeatedZombies == 5 || defeatedZombies + escapedZombies == 5)
+	{
+		defeatedZombies = 0;
+		escapedZombies = 0;
+		return 1;
+	}
+
+	else
+	{
+		return 0;
+	}
 }

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -353,7 +353,7 @@ int Grid::checkCollision(Player* player)
 		}
 	}
 
-	if (defeatedZombies == 5 || defeatedZombies + escapedZombies == 5)
+	if ((defeatedZombies == 5 || defeatedZombies + escapedZombies == 5) && player->getHealth() != 0)
 	{
 		defeatedZombies = 0;
 		escapedZombies = 0;

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -51,6 +51,7 @@ private:
 	Cactus cactus;
 	int numOfZombies = 0;
 	int defeatedZombies = 0;
+	int escapedZombies = 0;
 };
 
 #endif // !__GRID_H__


### PR DESCRIPTION
If less than 3 zombies escaped (not enough to kill the player), the level wouldn't change.